### PR TITLE
[2024.10.09] feat/#2 signup >> 회원가입 구현

### DIFF
--- a/src/main/java/com/ysy56/onboardingback/controller/UserController.java
+++ b/src/main/java/com/ysy56/onboardingback/controller/UserController.java
@@ -1,0 +1,26 @@
+package com.ysy56.onboardingback.controller;
+
+import com.ysy56.onboardingback.dto.SignupRequestDto;
+import com.ysy56.onboardingback.dto.SignupResponseDto;
+import com.ysy56.onboardingback.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<SignupResponseDto> signup(@RequestBody @Valid SignupRequestDto signupRequestDto) {
+        SignupResponseDto signupResponseDto = userService.signup(signupRequestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(signupResponseDto);
+    }
+
+}

--- a/src/main/java/com/ysy56/onboardingback/dto/SignupRequestDto.java
+++ b/src/main/java/com/ysy56/onboardingback/dto/SignupRequestDto.java
@@ -12,4 +12,7 @@ public class SignupRequestDto {
     @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;
 
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    private String nickname;
+
 }

--- a/src/main/java/com/ysy56/onboardingback/dto/SignupRequestDto.java
+++ b/src/main/java/com/ysy56/onboardingback/dto/SignupRequestDto.java
@@ -1,0 +1,15 @@
+package com.ysy56.onboardingback.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class SignupRequestDto {
+
+    @NotBlank(message = "아이디를 입력해주세요.")
+    private String username;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+
+}

--- a/src/main/java/com/ysy56/onboardingback/dto/SignupResponseDto.java
+++ b/src/main/java/com/ysy56/onboardingback/dto/SignupResponseDto.java
@@ -1,14 +1,15 @@
 package com.ysy56.onboardingback.dto;
 
+import java.util.List;
 import lombok.Getter;
 
 @Getter
 public class SignupResponseDto {
     private String username;
     private String nickname;
-    private String[] authorities;
+    private List<String> authorities;
 
-    public SignupResponseDto(String username, String nickname, String[] authorities) {
+    public SignupResponseDto(String username, String nickname, List<String> authorities) {
         this.username = username;
         this.nickname = nickname;
         this.authorities = authorities;

--- a/src/main/java/com/ysy56/onboardingback/dto/SignupResponseDto.java
+++ b/src/main/java/com/ysy56/onboardingback/dto/SignupResponseDto.java
@@ -1,0 +1,17 @@
+package com.ysy56.onboardingback.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SignupResponseDto {
+    private String username;
+    private String nickname;
+    private String[] authorities;
+
+    public SignupResponseDto(String username, String nickname, String[] authorities) {
+        this.username = username;
+        this.nickname = nickname;
+        this.authorities = authorities;
+    }
+
+}

--- a/src/main/java/com/ysy56/onboardingback/entity/Authority.java
+++ b/src/main/java/com/ysy56/onboardingback/entity/Authority.java
@@ -30,4 +30,8 @@ public class Authority {
 
     @OneToMany(mappedBy = "authority", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserAuthority> userAuthoritys = new ArrayList<>();
+
+    public Authority(String authorityName) {
+        this.authorityName = authorityName;
+    }
 }

--- a/src/main/java/com/ysy56/onboardingback/entity/Authority.java
+++ b/src/main/java/com/ysy56/onboardingback/entity/Authority.java
@@ -9,9 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/ysy56/onboardingback/entity/User.java
+++ b/src/main/java/com/ysy56/onboardingback/entity/User.java
@@ -9,9 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/ysy56/onboardingback/entity/User.java
+++ b/src/main/java/com/ysy56/onboardingback/entity/User.java
@@ -37,4 +37,10 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserAuthority> userAuthorities = new ArrayList<>();
 
+    public User(String username, String password, String nickname) {
+        this.username = username;
+        this.password = password;
+        this.nickname = nickname;
+    }
+
 }

--- a/src/main/java/com/ysy56/onboardingback/entity/UserAuthority.java
+++ b/src/main/java/com/ysy56/onboardingback/entity/UserAuthority.java
@@ -28,4 +28,8 @@ public class UserAuthority {
     @JoinColumn(name = "authority_id", nullable = false)
     private Authority authority;
 
+    public UserAuthority(User user, Authority authority) {
+        this.user = user;
+        this.authority = authority;
+    }
 }

--- a/src/main/java/com/ysy56/onboardingback/repository/AuthorityRepository.java
+++ b/src/main/java/com/ysy56/onboardingback/repository/AuthorityRepository.java
@@ -1,8 +1,11 @@
 package com.ysy56.onboardingback.repository;
 
 import com.ysy56.onboardingback.entity.Authority;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AuthorityRepository extends JpaRepository<Authority, Long> {
+
+    Optional<Authority> findByAuthorityName(String roleUser);
 
 }

--- a/src/main/java/com/ysy56/onboardingback/service/UserService.java
+++ b/src/main/java/com/ysy56/onboardingback/service/UserService.java
@@ -1,10 +1,21 @@
 package com.ysy56.onboardingback.service;
 
+import com.ysy56.onboardingback.entity.UserAuthority;
+import com.ysy56.onboardingback.repository.AuthorityRepository;
+import com.ysy56.onboardingback.repository.UserAuthorityRepository;
+import com.ysy56.onboardingback.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
+
+    private final UserRepository userRepository;
+    private final AuthorityRepository authorityRepository;
+    private final UserAuthorityRepository userAuthorityRepository;
+    private final PasswordEncoder passwordEncoder;
+
 
 }

--- a/src/main/java/com/ysy56/onboardingback/service/UserService.java
+++ b/src/main/java/com/ysy56/onboardingback/service/UserService.java
@@ -1,12 +1,19 @@
 package com.ysy56.onboardingback.service;
 
+import com.ysy56.onboardingback.dto.SignupRequestDto;
+import com.ysy56.onboardingback.dto.SignupResponseDto;
+import com.ysy56.onboardingback.entity.Authority;
+import com.ysy56.onboardingback.entity.User;
 import com.ysy56.onboardingback.entity.UserAuthority;
 import com.ysy56.onboardingback.repository.AuthorityRepository;
 import com.ysy56.onboardingback.repository.UserAuthorityRepository;
 import com.ysy56.onboardingback.repository.UserRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,5 +24,31 @@ public class UserService {
     private final UserAuthorityRepository userAuthorityRepository;
     private final PasswordEncoder passwordEncoder;
 
+    @Transactional
+    public SignupResponseDto signup(SignupRequestDto requestDto) {
+        // 기본 권한 설정 (ROLE_USER)
+        Authority authority = authorityRepository.findByAuthorityName("ROLE_USER")
+            .orElseThrow(() -> new RuntimeException("기본 권한을 찾을 수 없습니다."));
+
+        String encryptedPassword = passwordEncoder.encode(requestDto.getPassword());
+
+        // User 객체 생성 및 저장
+        User user = new User(requestDto.getUsername(), encryptedPassword, requestDto.getNickname());
+
+        // UserAuthority 객체 생성 및 User 객체에 추가
+        UserAuthority userAuthority = new UserAuthority(user, authority);
+        user.getUserAuthorities().add(userAuthority); // User에 UserAuthority 추가
+
+        // User 객체 저장
+        userRepository.save(user); // User 객체 저장 시 UserAuthority도 자동으로 저장됨
+
+        // 권한 목록 생성
+        List<String> authorities = user.getUserAuthorities().stream()
+            .map(ua -> ua.getAuthority().getAuthorityName())
+            .collect(Collectors.toList());
+
+        // SignupResponseDto 반환
+        return new SignupResponseDto(user.getUsername(), user.getNickname(), authorities);
+    }
 
 }

--- a/src/main/java/com/ysy56/onboardingback/service/UserService.java
+++ b/src/main/java/com/ysy56/onboardingback/service/UserService.java
@@ -1,0 +1,10 @@
+package com.ysy56.onboardingback.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #2 
> Close #2 

## 📑 작업 내용
> - 회원가입 구현

## 💭 기타(선택)
> 회원가입 시 1개의 역할만 세팅되도록 해놓았는데 해당 부분은 추후에 변경 예정.
> 한 개의 서비스에 많은 repository가 포함되어 단일 책임 원칙을 위배 중인 상황. 해당 부분도 수정 고려.
> 서비스로직 하나에 많은 DB 접근을 하고 있는 상태. queryDSL 고려 등 다양한 성능 문제 고민해볼 것.
